### PR TITLE
Hotfix: guard against stale mirror->tower links (0.5.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Editor/OS
+.DS_Store
+Thumbs.db
+desktop.ini
+*.swp
+*.swo
+*~
+*.bak
+*.tmp
+
+# IDEs
+.vscode/
+.idea/
+*.code-workspace
+
+# Logs
+*.log
+
+# Mod build artifacts
+*.zip

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.5.2
+Date: 2026.01.14
+  Bugfixes:
+    - Guard against stale mirror -> tower links when relinking (prevents crash when towers are
+      replaced by other mods).
+---------------------------------------------------------------------------------------------------
 Version: 0.5.1
 Date: 2025.07.19
   Changes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "ch-concentrated-solar",
-	"version": "0.5.1",
+  "version": "0.5.2",
 	"title": "Cheese's Concentrated Solar",
 	"author": "StolenCheese",
 	"factorio_version": "2.0",


### PR DESCRIPTION
## Summary
  - Clean up stale mirror->tower references during relink to avoid hard crashes when towers are replaced.
  - Improve compatibility with Quality Turrets Reworked by handling script-driven turret replacements safely.
  - Add .gitignore for common editor/OS files and mod ZIP build artifacts.
  - Bump version to 0.5.2 and document the hotfix.

  ## Context
  The crash occurs when another mod replaces a tower via script_raised_built/fast_replace, leaving mirrors briefly
  pointing at an invalid tower. This specifically showed up with Quality Turrets Reworked:
  https://github.com/xsoftwareforge/factorio-mod-quality-turret-reworked